### PR TITLE
Added new method Cacchern::SortedSet#where_by_score

### DIFF
--- a/lib/cacchern/sorted_set.rb
+++ b/lib/cacchern/sorted_set.rb
@@ -27,6 +27,13 @@ module Cacchern
       self.class.value_class.new(id, score)
     end
 
+    def where_by_score(min = '-inf', max = '+inf')
+      min = min.to_s if min.is_a? Numeric
+      max = max.to_s if max.is_a? Numeric
+      values = Redis.current.zrangebyscore @key, min, max, withscores: true
+      values.map { |value| self.class.value_class.new(value[0], value[1]) }
+    end
+
     def order(direction = :asc)
       values = case direction
                when :asc

--- a/lib/cacchern/sorted_set.rb
+++ b/lib/cacchern/sorted_set.rb
@@ -27,7 +27,7 @@ module Cacchern
       self.class.value_class.new(id, score)
     end
 
-    def where_by_score(min = '-inf', max = '+inf')
+    def where_by_score(min: '-inf', max: '+inf')
       min = min.to_s if min.is_a? Numeric
       max = max.to_s if max.is_a? Numeric
       values = Redis.current.zrangebyscore @key, min, max, withscores: true

--- a/spec/cacchern/sorted_set_spec.rb
+++ b/spec/cacchern/sorted_set_spec.rb
@@ -68,7 +68,14 @@ RSpec.describe Cacchern::SortedSet do
     end
 
     it { expect(sorted_set_instance.where_by_score.count).to eq 2 }
-    it { expect(sorted_set_instance.order(:asc)).to all(be_a(ScoreValue)) }
+    it { expect(sorted_set_instance.where_by_score).to all(be_a(ScoreValue)) }
+
+    it { expect(sorted_set_instance.where_by_score(max: 0).count).to eq 0 }
+
+    it { expect(sorted_set_instance.where_by_score(min: 0, max: 300).count).to eq 2 }
+
+    it { expect(sorted_set_instance.where_by_score(min: 0, max: 150).count).to eq 1 }
+    it { expect(sorted_set_instance.where_by_score(min: 0, max: 150).first.key).to eq value1.key.to_s }
   end
 
   describe '#order' do

--- a/spec/cacchern/sorted_set_spec.rb
+++ b/spec/cacchern/sorted_set_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe Cacchern::SortedSet do
     end
   end
 
+  describe '#where_by_score' do
+    let(:sorted_set_instance) { ScoreSortedSet.new('base') }
+    let(:value1) { ScoreValue.new(1, 100) }
+    let(:value2) { ScoreValue.new(2, 200) }
+
+    before do
+      sorted_set_instance.add(value1)
+      sorted_set_instance.add(value2)
+    end
+
+    it { expect(sorted_set_instance.where_by_score.count).to eq 2 }
+    it { expect(sorted_set_instance.order(:asc)).to all(be_a(ScoreValue)) }
+  end
+
   describe '#order' do
     let(:sorted_set_instance) { ScoreSortedSet.new('base') }
     let(:value1) { ScoreValue.new(1, 100) }


### PR DESCRIPTION
I added new method Cacchern::SortedSet#where_by_score.

Cacchern::SortedSet#where_by_score(min, max)
returns its members whose score is between min and max.

**references**
- http://redis.shibu.jp/commandreference/sortedsets.html#command-ZRANGEBYSCORE
- https://www.rubydoc.info/github/redis/redis-rb/Redis#zrangebyscore-instance_method